### PR TITLE
Correcting the url to original article after changes to their website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A checklist of important security issues you should consider when creating a web
 
 ## Introduction
 
-[This checklist](#the-checklist) has been reproduced verbatim from [Michael O' Brien](https://simplesecurity.sensedeep.com/@sensedeep)'s blog post by the [same name](https://simplesecurity.sensedeep.com/web-developer-security-checklist-f2e4f43c9c56).
+[This checklist](#the-checklist) has been reproduced verbatim from [Michael O' Brien](https://simplesecurity.sensedeep.com/@sensedeep)'s blog post by the [same name](https://www.sensedeep.com/blog/posts/stories/web-developer-security-checklist.html).
 
 ## Contents
 - [Database](#database)


### PR DESCRIPTION
After changes to their url structure the link didn't work. I've updated it to the latest version of the checklist. There are changes to the checklist on the site but I have not included those changes in this pull request and will instead make an issue about it since I don't want to assume that you want to use those changes.